### PR TITLE
Version the generated specs automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.DS_Store
 /dist/
 .DS_Store
+variables.tsp

--- a/main.tsp
+++ b/main.tsp
@@ -1,6 +1,7 @@
 import "@typespec/http";
 import "@typespec/openapi";
 import "@typespec/json-schema";
+import "./variables.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
@@ -8,7 +9,7 @@ using TypeSpec.JsonSchema;
 
 @service({
   title: "ZeroTierOne Service",
-  version: "2024-02-13::1.12.2",
+  version: Version,
 })
 @info({
   license: {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "tsx test/*test.ts",
     "build": "run-s pre-compile compile lint build:*",
     "lint": "run-p lint:*",
-    "pre-compile": "run-p depcheck format-spec format-code",
+    "pre-compile": "run-p depcheck format-spec format-code variables",
     "build:doc-html": "redocly build-docs tsp-output/@typespec/openapi3/openapi.yaml -o ./dist/index.html",
     "pretest": "openapi-typescript tsp-output/@typespec/openapi3/openapi.yaml -o /tmp/schema.ts",
     "clean": "rm -rf dist tsp-output",
@@ -19,6 +19,7 @@
     "gh:tag": "git tag -d v${npm_package_version}; git tag v${npm_package_version}",
     "release": "npm run gh:tag && git push --tags && gh-release -y -a=tsp-output/@typespec/openapi3/openapi.yaml,tsp-output/@typespec/json-schema/json-schema.json",
     "version": "auto-changelog -p --template keepachangelog auto-changelog --breaking-pattern 'BREAKING CHANGE:' && git add CHANGELOG.md",
+    "variables": "printf 'alias Version = \"%s\";\n' $npm_package_version > variables.tsp",
     "watch": "run-p watch:*",
     "watch:compile": "npm run compile -- --watch",
     "watch:serve": "redocly preview-docs ./tsp-output/@typespec/openapi3/openapi.yaml --use-community-edition"


### PR DESCRIPTION
keep them in step with the npm package version
which is also the github release tag/version.

there's currently  no straigtforward way to
compile time send variables into a spec.

So we generate a variables.tsp file from a "template" The template is

`printf 'alias Version = \"%s\";\n' $npm_package_version > variables.tsp`