### PR TITLE
Fixes for minor API deviations

### DIFF
--- a/main.tsp
+++ b/main.tsp
@@ -403,7 +403,7 @@ model ControllerNetworkMember {
   creationTime: uSafeint;
   identity?: string;
   lastAuthorizedCredential: string | null;
-  lastAuthorizedCredentialType: string;
+  lastAuthorizedCredentialType: string | null;
   lastAuthorizedTime: uSafeint;
   lastDeauthorizedTime: uSafeint;
   nwid: ZTNetworkID;

--- a/main.tsp
+++ b/main.tsp
@@ -1,5 +1,6 @@
 import "@typespec/http";
 import "@typespec/openapi";
+import "@typespec/openapi3";
 import "@typespec/json-schema";
 import "./variables.tsp";
 
@@ -458,7 +459,11 @@ scalar IPv4 extends string;
 @format("ipv6")
 scalar IPv6 extends string;
 
-alias IP = IPv4 | IPv6;
+@oneOf
+union IP {
+  ipv4: IPv4,
+  ipv6: IPv6,
+}
 
 scalar IPSlashPort extends string;
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -57,7 +57,7 @@ function assertValid(
 
 const ZEROTIER_API_SECRET = "asdf";
 
-describe("API exercise", async function() {
+describe("API exercise", async function () {
   let network_id: string;
   const node_id = "1122334455";
   let container;
@@ -81,7 +81,7 @@ describe("API exercise", async function() {
     client = createCreateClient(ZEROTIER_API_SECRET, apiPort);
   });
 
-  describe("GET endpoints", async function() {
+  describe("GET endpoints", async function () {
     const map: { path: PathsWithMethod<paths, "get">; id: string }[] = [
       { path: "/status", id: "NodeStatus" },
       { path: "/controller", id: "ControllerStatus" },


### PR DESCRIPTION
Hello all,

While using this API as a reference for some personal projects, I noticed a few minor compatibility issues between this spec and what is returned. I wanted to know if there was any interest in merging any of these changes. If not, I'll happily maintain my fork for my projects.

Specifically, I noticed two issues:
- `ControllerNetworkMember` does not mark `lastAuthorizedCredentialType` as nullable ([link](https://github.com/zerotier/zerotier-one-api-spec/blob/main/main.tsp#L396-L405)).
- The type alias `IP` is not marked as `oneOf` ([link](https://github.com/zerotier/zerotier-one-api-spec/blob/main/main.tsp#L396-L405))

The first issue can cause problems when a node has joined a private network but has not yet been authorized since the network controller will return null for that field. I fixed this by marking the field as nullable. The second issue is more of a compatibility issue. The official Rust crate for Zerotier [depends on `progenitor`](https://crates.io/crates/zerotier-one-api/1.2.1/dependencies), which currently has several bugs related to `anyOf` string fields with format options (ex. "ipv4"). This means that requests to `/controller/network/{network_id}/member/{node_id}` will always fail to deserialize when using the official API spec and the official ZeroTier crate. I fixed this by marking converting the alias to a union and marking it as `oneOf`.

Thank you for your time, and for the API spec!